### PR TITLE
Minor typo correction to Poll.pm POD

### DIFF
--- a/dist/IO/lib/IO/Poll.pm
+++ b/dist/IO/lib/IO/Poll.pm
@@ -186,7 +186,7 @@ Remove IO from the list of file descriptors for the next poll.
 Returns a list of handles. If EVENT_MASK is not given then a list of all
 handles known will be returned. If EVENT_MASK is given then a list
 of handles will be returned which had one of the events specified by
-EVENT_MASK happen during the last call ti C<poll>
+EVENT_MASK happen during the last call to C<poll>
 
 =back
 


### PR DESCRIPTION
<!--
A good description should explain the problem the pull request addresses
and give context to the reviewers to aid them in their reviews.
-->
IO::Poll POD description of `handle` refers to "the last call ti `poll`".  This commit corrects "ti" to "to".
<!--
Significant changes to Perl must be documented in perldelta.

Consider if the changes in this pull request are worthy of a perldelta
entry, then pick the appropriate line below and remove the others.
-->
---------------------------------------------------------------------------------
* This set of changes does not require a perldelta entry.
